### PR TITLE
/etc/vimrc on FreeBSD should be owned by 'root:wheel'

### DIFF
--- a/vim/init.sls
+++ b/vim/init.sls
@@ -10,7 +10,7 @@ vim:
     - source: salt://vim/files/vimrc
     - template: jinja
     - user: root
-    - group: root
+    - group: {{ vim.group }}
     - mode: 644
     - template: jinja
     - makedirs: True

--- a/vim/map.jinja
+++ b/vim/map.jinja
@@ -2,21 +2,26 @@
     'Arch': {
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/vimfiles',
+        'group': 'root',
     },
     'Debian': {
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/vimfiles',
+        'group': 'root',
     },
     'RedHat': {
         'pkg': 'vim-enhanced',
         'share_dir': '/usr/share/vim/vimfiles',
+        'group': 'root',
     },
     'Suse': {
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/site',
+        'group', 'root',
     },
     'FreeBSD': {
         'pkg': 'vim',
         'share_dir': '/usr/local/share/vim/vimfiles',
+        'group': 'wheel',
     },
 }, merge=salt['pillar.get']('vim:lookup')) %}

--- a/vim/map.jinja
+++ b/vim/map.jinja
@@ -17,7 +17,7 @@
     'Suse': {
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/site',
-        'group', 'root',
+        'group': 'root',
     },
     'FreeBSD': {
         'pkg': 'vim',


### PR DESCRIPTION
There is no group 'root' on a vanilla FreeBSD install.

This patch makes sure we use the correct group for the correct OS

fixes #21 