### PR TITLE
debian runtime config

### DIFF
--- a/vim/files/vimrc
+++ b/vim/files/vimrc
@@ -38,6 +38,10 @@ let {{ parameter }} = {{ value }}
 {{ set_config('runtime!', 'archlinux.vim') }}
 {% endif %}
 
+{% if grains['os'] == 'Debian'%}
+{{ set_config('runtime!', 'debian.vim') }}
+{% endif %}
+
 {% for parameter in config -%}
 {{ set_config(parameter) }}
 {% endfor -%}


### PR DESCRIPTION
Distro-specific config files states:

    " This line should not be removed as it ensures that various options are
    " properly set to work with the Vim-related packages available in Debian.

this change put it back on generated vimrc