### PR TITLE
correct vimrc path on Debian

### DIFF
--- a/vim/init.sls
+++ b/vim/init.sls
@@ -4,7 +4,7 @@ vim:
   pkg.installed:
     - name: {{ vim.pkg }}
 
-/etc/vimrc:
+{{ vim.config_root }}/vimrc:
   file:
     - managed
     - source: salt://vim/files/vimrc

--- a/vim/map.jinja
+++ b/vim/map.jinja
@@ -3,25 +3,30 @@
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/vimfiles',
         'group': 'root',
+        'config_root': '/etc',
     },
     'Debian': {
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/vimfiles',
         'group': 'root',
+        'config_root': '/etc/vim',
     },
     'RedHat': {
         'pkg': 'vim-enhanced',
         'share_dir': '/usr/share/vim/vimfiles',
         'group': 'root',
+        'config_root': '/etc',
     },
     'Suse': {
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/site',
         'group': 'root',
+        'config_root': '/etc',
     },
     'FreeBSD': {
         'pkg': 'vim',
         'share_dir': '/usr/local/share/vim/vimfiles',
         'group': 'wheel',
+        'config_root': '/etc',
     },
 }, merge=salt['pillar.get']('vim:lookup')) %}


### PR DESCRIPTION
vimrc path in Debian is under /etc/vim, this change put that file on the right place