### PR TITLE
allow for localrc, if needed

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 vim:
+  allow_localrc: false
   config:
     syntax: 'on'
     colors: desert

--- a/vim/files/vimrc
+++ b/vim/files/vimrc
@@ -2,6 +2,7 @@
 {% set settings = salt['pillar.get']('vim:settings', {}) -%}
 {% set mappings = salt['pillar.get']('vim:mappings', {}) -%}
 {% set lets = salt['pillar.get']('vim:lets', {}) -%}
+{% set allow_localrc = salt['pillar.get']('vim:allow_localrc', {}) -%}
 
 {% macro set_config(parameter, default=None) -%}
 {% set value = config.get(parameter, default) -%}
@@ -54,3 +55,8 @@ let {{ parameter }} = {{ value }}
 {{ set_let(parameter) }}
 {% endfor -%}
 
+{% if allow_localrc == True %}
+if filereadable("{{ config_root }}/vimrc.local")
+    source {{ config_root }}/vimrc.local
+endif
+{% endif %}

--- a/vim/init.sls
+++ b/vim/init.sls
@@ -4,7 +4,7 @@ vim:
   pkg.installed:
     - name: {{ vim.pkg }}
 
-/etc/vimrc:
+{{ vim.config_root }}/vimrc:
   file:
     - managed
     - source: salt://vim/files/vimrc
@@ -16,4 +16,6 @@ vim:
     - makedirs: True
     - require:
       - pkg: vim
+    - defaults:
+        config_root: {{ vim.config_root }}
 

--- a/vim/map.jinja
+++ b/vim/map.jinja
@@ -3,25 +3,30 @@
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/vimfiles',
         'group': 'root',
+        'config_root': '/etc',
     },
     'Debian': {
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/vimfiles',
         'group': 'root',
+        'config_root': '/etc/vim',
     },
     'RedHat': {
         'pkg': 'vim-enhanced',
         'share_dir': '/usr/share/vim/vimfiles',
         'group': 'root',
+        'config_root': '/etc',
     },
     'Suse': {
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/site',
         'group': 'root',
+        'config_root': '/etc',
     },
     'FreeBSD': {
         'pkg': 'vim',
         'share_dir': '/usr/local/share/vim/vimfiles',
         'group': 'wheel',
+        'config_root': '/etc',
     },
 }, merge=salt['pillar.get']('vim:lookup')) %}


### PR DESCRIPTION
this patch let user choose to still allow for a localrc file to be included at the end of vimrc. This could be useful for modifications outside of salt-managed file