### PR TITLE
Make vimrc management optional

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 vim:
+  managed_vimrc: true
   allow_localrc: false
   config:
     syntax: 'on'

--- a/vim/init.sls
+++ b/vim/init.sls
@@ -4,9 +4,9 @@ vim:
   pkg.installed:
     - name: {{ vim.pkg }}
 
+{% if salt['pillar.get']('vim:managed_vimrc', True) == True %}
 {{ vim.config_root }}/vimrc:
-  file:
-    - managed
+  file.managed:
     - source: salt://vim/files/vimrc
     - template: jinja
     - user: root
@@ -18,4 +18,4 @@ vim:
       - pkg: vim
     - defaults:
         config_root: {{ vim.config_root }}
-
+{% endif %}


### PR DESCRIPTION
Possible solution for #16. I think it's better to put the option under vim:managed_vimrc instead of setting it in the map.jinja file. If I understood the function correctly [this line](https://github.com/devster31/vim-formula/blob/0033d68f9858a0ee1e809fef645a73db26fea30a/vim/init.sls#L7) should maintain the current behaviour but allow the users to turn it off.