### PR TITLE
Remove whitespace

### DIFF
--- a/vim/files/vimrc
+++ b/vim/files/vimrc
@@ -34,14 +34,13 @@ let {{ parameter }} = {{ value }}
 {% endif -%}
 {% endmacro -%}
 
-
-{% if grains['os'] == 'Arch'%}
+{% if grains['os'] == 'Arch' -%}
 {{ set_config('runtime!', 'archlinux.vim') }}
-{% endif %}
+{% endif -%}
 
-{% if grains['os'] == 'Debian'%}
+{% if grains['os'] == 'Debian' -%}
 {{ set_config('runtime!', 'debian.vim') }}
-{% endif %}
+{% endif -%}
 
 {% for parameter in config -%}
 {{ set_config(parameter) }}
@@ -59,7 +58,7 @@ let {{ parameter }} = {{ value }}
 {{ set_let(parameter) }}
 {% endfor -%}
 
-{% if allow_localrc == True %}
+{% if allow_localrc == True -%}
 if filereadable("{{ config_root }}/vimrc.local")
     source {{ config_root }}/vimrc.local
 endif


### PR DESCRIPTION
Remove some of the empty lines left in the template, almost every logic block should have this but according to saltstack/salt#8333 and saltstack/salt#8356 neither _trim_blocks_ nor _lstrip_blocks_ are enabled by default. Editor also added trailing newline.