### PR TITLE
Added support for OpenBSD

### DIFF
--- a/vim/map.jinja
+++ b/vim/map.jinja
@@ -11,6 +11,12 @@
         'group': 'root',
         'config_root': '/etc/vim',
     },
+    'OpenBSD': {
+        'pkg': 'vim--no_x11',
+        'share_dir': '/usr/local/share/vim/vimfiles',
+        'group': 'wheel',
+        'config_root': '/etc',
+    },
     'RedHat': {
         'pkg': 'vim-enhanced',
         'share_dir': '/usr/share/vim/vimfiles',


### PR DESCRIPTION
One is able to install the headless version of vim by issuing `$ pkg_add
vim--no_x11`, the same works within salt.