### PR TITLE
Changed Alternatives usage for Debian

### DIFF
--- a/vim/editor.sls
+++ b/vim/editor.sls
@@ -2,9 +2,23 @@
 
 include:
   - vim
-  
-editor:
+
+{% if vim.has_key('alternatives') %}
+  {% set alt = vim.alternatives %}
+  {% if alt.has_key('link') and alt.has_key('path') and alt.has_key('priority') %}
+    {% if salt['alternatives.show_current']('editor') != alt.path %}
+install_editor_alternative:
   alternatives.install:
-    - link: /usr/bin/editor
-    - path: /usr/bin/vim
-    - priority: 100
+    - name: editor
+    - link: {{ alt.link }}
+    - path: {{ alt.path }}
+    - priority: {{ alt.priority }}
+
+ensure_editor_alternative:
+  alternatives.auto:
+    - name: editor
+    - require:
+      - alternatives: install_editor_alternative
+    {% endif %}
+  {% endif %}
+{% endif %}

--- a/vim/map.jinja
+++ b/vim/map.jinja
@@ -6,6 +6,11 @@
         'config_root': '/etc',
     },
     'Debian': {
+        'alternatives': {
+            'link': '/usr/bin/editor',
+            'path': '/usr/bin/vim.basic',
+            'priority': 100,
+        },
         'pkg': 'vim',
         'share_dir': '/usr/share/vim/vimfiles',
         'group': 'root',


### PR DESCRIPTION
The way that `vim-formula` currently handles the alternative settings
for the `/usr/bin/editor` symlink on Debian based machines is incorrect,
this was brought up in saltstack-formulas/vim-formula#29.

I tested this on Debian, Ubuntu, and CentOS (the `editor` symlink does
not exist by default on this OS) and it seems to work as
expected now.