### PR TITLE
Fix path to vim alternatives, closes: #29

### DIFF
--- a/vim/map.jinja
+++ b/vim/map.jinja
@@ -8,7 +8,7 @@
     'Debian': {
         'alternatives': {
             'link': '/usr/bin/editor',
-            'path': '/usr/bin/vim.basic',
+            'path': '/usr/bin/vim',
             'priority': 100,
         },
         'pkg': 'vim',


### PR DESCRIPTION
states module wants path to match the one set by alternatives, however
both editor and vim have alternatives thus /usr/bin/vim is a symlink
to its alternative and does not equal /usr/bin/vim.basic.

Tested on Debian 9 and Ubuntu 16.04 using salt 2017.7.5.