### PR TITLE
iteritems() -> items() (Python 3.6)

### DIFF
--- a/vim/files/pyflakes/ftplugin/python/pyflakes/pyflakes/checker.py
+++ b/vim/files/pyflakes/ftplugin/python/pyflakes/pyflakes/checker.py
@@ -557,7 +557,7 @@ class Checker(object):
                 """
                 Check to see if any assignments have not been used.
                 """
-                for name, binding in self.scope.iteritems():
+                for name, binding in self.scope.items():
                     if (not binding.used and not name in self.scope.globals
                         and isinstance(binding, Assignment)):
                         self.report(messages.UnusedVariable,


### PR DESCRIPTION
Ensure Python 3.6 compatibility.

Tested on FreeBSD 11.2.